### PR TITLE
Add the option to never allow MO to be closed when application is run (Part 2)

### DIFF
--- a/src/executableinfo.cpp
+++ b/src/executableinfo.cpp
@@ -7,7 +7,6 @@ MOBase::ExecutableInfo::ExecutableInfo(const QString &title, const QFileInfo &bi
   : m_Title(title)
   , m_Binary(binary)
   , m_WorkingDirectory(binary.exists() ? binary.absoluteDir() : QString())
-  , m_CloseMO(CloseMOStyle::DEFAULT_STAY)
   , m_SteamAppID()
 {
 }
@@ -32,13 +31,21 @@ ExecutableInfo &MOBase::ExecutableInfo::withSteamAppId(const QString &appId)
 
 ExecutableInfo &ExecutableInfo::withDefaultClose()
 {
-  m_CloseMO = CloseMOStyle::DEFAULT_CLOSE;
+  m_CloseByDefault = true;
   return *this;
 }
 
 ExecutableInfo &ExecutableInfo::withNeverClose()
 {
-  m_CloseMO = CloseMOStyle::NEVER_CLOSE;
+  m_CloseByDefault = false;
+  m_DisableCloseSelection = true;
+  return *this;
+}
+
+ExecutableInfo &ExecutableInfo::withAlwaysClose()
+{
+  m_CloseByDefault = true;
+  m_DisableCloseSelection = true;
   return *this;
 }
 
@@ -73,11 +80,6 @@ QDir ExecutableInfo::workingDirectory() const
   return m_WorkingDirectory;
 }
 
-ExecutableInfo::CloseMOStyle ExecutableInfo::closeMO() const
-{
-  return m_CloseMO;
-}
-
 QString ExecutableInfo::steamAppID() const
 {
   return m_SteamAppID;
@@ -86,4 +88,14 @@ QString ExecutableInfo::steamAppID() const
 bool ExecutableInfo::isCustom() const
 {
   return m_Custom;
+}
+
+bool ExecutableInfo::closeByDefault() const
+{
+  return m_CloseByDefault;
+}
+
+bool ExecutableInfo::disableCloseSelection() const
+{
+  return m_DisableCloseSelection;
 }

--- a/src/executableinfo.h
+++ b/src/executableinfo.h
@@ -14,14 +14,6 @@ class QDLLEXPORT ExecutableInfo
 {
 public:
 
-  enum class CloseMOStyle {
-    DEFAULT_CLOSE = 1,
-    DEFAULT_STAY = 2,
-    NEVER_CLOSE = 3
-  };
-
-public:
-
   ExecutableInfo(const QString &title, const QFileInfo &binary);
 
   ExecutableInfo &withArgument(const QString &argument);
@@ -34,6 +26,8 @@ public:
 
   ExecutableInfo &withNeverClose();
 
+  ExecutableInfo &withAlwaysClose();
+
   ExecutableInfo &asCustom();
 
   bool isValid() const;
@@ -42,9 +36,10 @@ public:
   QFileInfo binary() const;
   QStringList arguments() const;
   QDir workingDirectory() const;
-  CloseMOStyle closeMO() const;
   QString steamAppID() const;
   bool isCustom() const;
+  bool closeByDefault() const;
+  bool disableCloseSelection() const;
 
 private:
 
@@ -52,9 +47,10 @@ private:
   QFileInfo m_Binary;
   QStringList m_Arguments;
   QDir m_WorkingDirectory;
-  CloseMOStyle m_CloseMO { CloseMOStyle::DEFAULT_STAY };
   QString m_SteamAppID;
   bool m_Custom { false };
+  bool m_CloseByDefault { false };
+  bool m_DisableCloseSelection { false };
 
 };
 


### PR DESCRIPTION
Argh. This is the other half of the add never close pull - spent some time tracking these down.

See also: https://github.com/TanninOne/modorganizer/pull/2

Fix for TanninOne/modorganizer#387
