### PR TITLE
New vfs library

### DIFF
--- a/src/versioninfo.cpp
+++ b/src/versioninfo.cpp
@@ -39,6 +39,18 @@ VersionInfo::VersionInfo()
 {
 }
 
+VersionInfo::VersionInfo(int major, int minor, int subminor, int subsubminor, ReleaseType releaseType)
+  : m_Scheme(SCHEME_REGULAR)
+  , m_Valid(true)
+  , m_ReleaseType(releaseType)
+  , m_Major(major)
+  , m_Minor(minor)
+  , m_SubMinor(subminor)
+  , m_SubSubMinor(subsubminor)
+  , m_DecimalPositions(0)
+  , m_Rest()
+{
+}
 
 VersionInfo::VersionInfo(int major, int minor, int subminor, ReleaseType releaseType)
   : m_Scheme(SCHEME_REGULAR)
@@ -102,10 +114,10 @@ QString VersionInfo::canonicalString() const
   } else if (m_Scheme == SCHEME_DECIMALMARK) {
     result = QString("f%1.%2").arg(m_Major).arg(QString("%1").arg(m_Minor).rightJustified(m_DecimalPositions, '0'));
   } else if (m_Scheme == SCHEME_NUMBERSANDLETTERS) {
-    result = QString("n%1.%2.%3").arg(m_Major).arg(m_Minor).arg(m_SubMinor);
+    result = QString("n%1.%2.%3.%4").arg(m_Major).arg(m_Minor).arg(m_SubMinor).arg(m_SubSubMinor);
   } else if (m_Scheme == SCHEME_DATE) {
     // year.month.day was stored in the version fields
-    result = QString("d%1.%2.%3").arg(m_Major).arg(m_Minor).arg(m_SubMinor);
+    result = QString("d%1.%2.%3.%4").arg(m_Major).arg(m_Minor).arg(m_SubMinor)).arg(m_SubSubMinor);
   }
   switch (m_ReleaseType) {
     case RELEASE_PREALPHA: {
@@ -150,7 +162,7 @@ QString VersionInfo::displayString() const
   } else if (m_Scheme == SCHEME_DECIMALMARK) {
     result = QString("%1.%2").arg(m_Major).arg(QString("%1").arg(m_Minor).rightJustified(m_DecimalPositions, '0'));
   } else if (m_Scheme == SCHEME_NUMBERSANDLETTERS) {
-    result = QString("%1.%2.%3").arg(m_Major).arg(m_Minor).arg(m_SubMinor);
+    result = QString("%1.%2.%3.%4").arg(m_Major).arg(m_Minor).arg(m_SubMinor).arg(m_SubSubMinor);
   } else if (m_Scheme == SCHEME_DATE) {
     // year.month.day was stored in the version fields
     result = QString("%1-%2-%3").arg(m_Major).arg(QString("%1").arg(m_Minor).rightJustified(2, '0')).arg(QString("%1").arg(m_SubMinor).rightJustified(2, '0'));

--- a/src/versioninfo.cpp
+++ b/src/versioninfo.cpp
@@ -117,7 +117,7 @@ QString VersionInfo::canonicalString() const
     result = QString("n%1.%2.%3.%4").arg(m_Major).arg(m_Minor).arg(m_SubMinor).arg(m_SubSubMinor);
   } else if (m_Scheme == SCHEME_DATE) {
     // year.month.day was stored in the version fields
-    result = QString("d%1.%2.%3.%4").arg(m_Major).arg(m_Minor).arg(m_SubMinor)).arg(m_SubSubMinor);
+    result = QString("d%1.%2.%3.%4").arg(m_Major).arg(m_Minor).arg(m_SubMinor).arg(m_SubSubMinor);
   }
   switch (m_ReleaseType) {
     case RELEASE_PREALPHA: {

--- a/src/versioninfo.h
+++ b/src/versioninfo.h
@@ -78,6 +78,16 @@ public:
    * @param releaseType release type
    */
   VersionInfo(int major, int minor, int subminor, ReleaseType releaseType = RELEASE_FINAL);
+  
+   /**
+   * @brief constructor
+   * @param major major version
+   * @param minor minor version
+   * @param subminor subminor version
+   * @param subsubminor subsubminor version
+   * @param releaseType release type
+   */
+  VersionInfo(int major, int minor, int subminor, int subsubminor, ReleaseType releaseType = RELEASE_FINAL);
 
   /**
    * @brief constructor


### PR DESCRIPTION
Added support to use a build number for minor fixes instead of updating the minor should allow more frequent builds that don't include to many major changes.